### PR TITLE
fix doc: change git clone source to current repo: Boritech-Solutions/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ https://github.com/Boritech-Solutions/PyEarthworm/releases/latest) pre-compiled 
 ### Install from source
 
 ```
-git clone https://github.com/cmalek/PyEarthworm
+git clone https://github.com/Boritech-Solutions/PyEarthworm
 cd PyEarthworm
 pip install cython numpy
 python setup.py install
@@ -57,7 +57,7 @@ python setup.py install
 ### Build without installing
 
 ```
-git clone https://github.com/cmalek/PyEarthworm
+git clone https://github.com/Boritech-Solutions/PyEarthworm
 cd PyEarthworm
 pip install cython numpy
 python setup.py build_ext -i


### PR DESCRIPTION
When I follow the instructions compiling the source, I encounter an error message:

```Compiling src/PyEW.pyx because it changed.
[1/1] Cythonizing src/PyEW.pyx
/home/jimmy/miniconda3/envs/PyEW/lib/python3.12/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /home/jimmy/PyEarthworm/src/PyEW.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)

Error compiling Cython file:
------------------------------------------------------------
...
  def req_syssta(self):
    if self.OK:
      logger.info("Requesting system status")
      msg = self.default_ring.reqsta()
      status = msg[1][:msg[0]].decode('UTF-8')
      print status
            ^
------------------------------------------------------------

src/PyEW.pyx:324:12: Syntax error in simple statement list
Traceback (most recent call last):
  File "/home/jimmy/PyEarthworm/setup.py", line 83, in <module>
    ext_modules=cythonize(Extension('PyEW', ['src/PyEW.pyx'])),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jimmy/miniconda3/envs/PyEW/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1154, in cythonize
    cythonize_one(*args)
  File "/home/jimmy/miniconda3/envs/PyEW/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1321, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: src/PyEW.pyx
```

I check the `src/PyEW.pyx` and found that it use py2 syntax, then I found the instructions in readme is wrong. 
So I fix it by changing from https://github.com/cmalek/PyEarthworm to https://github.com/Boritech-Solutions/PyEarthworm